### PR TITLE
fix(dbus): fail if cannot be primary notification server

### DIFF
--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -1,4 +1,4 @@
-use crate::error;
+use crate::error::{self, Error};
 use crate::notification::{Action, Notification};
 use dbus::arg::{RefArg, Variant};
 use dbus::blocking::stdintf::org_freedesktop_dbus::RequestNameReply;
@@ -156,13 +156,11 @@ impl DbusServer {
         let reply = self
             .connection
             .request_name(NOTIFICATION_INTERFACE, false, true, false)?;
-
         if reply != RequestNameReply::PrimaryOwner {
-            return Err(error::Error::InitError(
+            return Err(Error::Init(
                 "Not primary D-Bus notification server, is another running?".to_string(),
             ));
         }
-
         let token = dbus_server::register_org_freedesktop_notifications(&mut self.crossroads);
         self.crossroads.insert(
             NOTIFICATION_PATH,

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -1,6 +1,7 @@
 use crate::error;
 use crate::notification::{Action, Notification};
 use dbus::arg::{RefArg, Variant};
+use dbus::blocking::stdintf::org_freedesktop_dbus::RequestNameReply;
 use dbus::blocking::{Connection, Proxy};
 use dbus::channel::MatchingReceiver;
 use dbus::message::MatchRule;
@@ -152,8 +153,16 @@ impl DbusServer {
         sender: Sender<Action>,
         timeout: Duration,
     ) -> error::Result<()> {
-        self.connection
+        let reply = self
+            .connection
             .request_name(NOTIFICATION_INTERFACE, false, true, false)?;
+
+        if reply != RequestNameReply::PrimaryOwner {
+            return Err(error::Error::InitError(
+                "Not primary D-Bus notification server, is another running?".to_string(),
+            ));
+        }
+
         let token = dbus_server::register_org_freedesktop_notifications(&mut self.crossroads);
         self.crossroads.insert(
             NOTIFICATION_PATH,

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,8 @@ pub enum Error {
     SystemTime(#[from] std::time::SystemTimeError),
     #[error("Config error: `{0}`")]
     Config(String),
+    #[error("Init error")]
+    InitError(String),
 }
 
 /// Type alias for the standard [`Result`] type.

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,8 +40,8 @@ pub enum Error {
     SystemTime(#[from] std::time::SystemTimeError),
     #[error("Config error: `{0}`")]
     Config(String),
-    #[error("Init error")]
-    InitError(String),
+    #[error("Init error: `{0}")]
+    Init(String),
 }
 
 /// Type alias for the standard [`Result`] type.


### PR DESCRIPTION
Addresses https://github.com/orhun/runst/issues/87

## Description

See https://github.com/orhun/runst/issues/87 for details

## Motivation and Context

Prevents the server from starting but doing nothing in the case that another service is primary for this D-Bus name

## How Has This Been Tested?

Before change, running Regolith desktop on Ubuntu 23.04.  By default the `rofication` demon holds the notification name in D-Bus:

```
$ cargo run
   Compiling runst v0.1.4 (/home/kgilmer/dev/repos/runst)
    Finished dev [unoptimized + debuginfo] target(s) in 3.20s
     Running `target/debug/runst`
2023-08-06T22:27:02.576823Z  INFO runst: starting
```

However `runst` does not show notifications with `notify-send`.

After change, program aborts:

```shell
$ cargo run
...
Running `target/debug/runst`
2023-08-06T22:18:40.543262Z  INFO runst: starting
thread '<unnamed>' panicked at 'failed to register D-Bus notification handler: InitializationError("Not primary D-Bus notification server, is another running?")', src/lib.rs:85:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)
```

Additionally, killing the name holder, then running `runst`, results in showing notifications with `notify-send`.  (Note: I shortened the name of the error type after running the above test)

## Screenshots / Logs (if applicable)

unnecessary

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [X] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [X] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [-] I have added tests to cover my changes.
  Unclear how a unit test could be added here without bigger changes
- [X] All new and existing tests passed.
