### PR TITLE
refactor: replace format! with concat! for string literals

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ impl Config {
             env::var(CONFIG_ENV).ok().map(PathBuf::from),
             dirs::config_dir().map(|p| p.join(env!("CARGO_PKG_NAME")).join(DEFAULT_CONFIG)),
             dirs::home_dir().map(|p| {
-                p.join(format!(".{}", env!("CARGO_PKG_NAME")))
+                p.join(concat!(".", env!("CARGO_PKG_NAME")))
                     .join(DEFAULT_CONFIG)
             }),
         ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub fn run() -> Result<()> {
         dbus_client.notify(
             env!("CARGO_PKG_NAME"),
             "startup",
-            &format!("{} is up and running 🦡", env!("CARGO_PKG_NAME")),
+            concat!(env!("CARGO_PKG_NAME"), " is up and running 🦡"),
             -1,
         )?;
     }


### PR DESCRIPTION
## Description

- Replace `format!` with `concat!` for string literals

## Motivation and Context

- Although `format`! macro is very powerful, it introduces overhead of memory allocation on the heap compared to `&str`. Therefore, when `format!` macro is unnecessary, we should avoid using it.

## How Has This Been Tested?

- `cargo test` passed.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
