### PR TITLE
fix: use newer APIs with sscanf and pango

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use rust_embed::RustEmbed;
 use serde::de::{Deserializer, Error as SerdeError};
 use serde::ser::Serializer;
 use serde::{Deserialize, Serialize};
-use sscanf::scanf;
+use sscanf::sscanf;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -134,7 +134,7 @@ impl FromStr for Geometry {
     type Err = Error;
     fn from_str(s: &str) -> StdResult<Self, Self::Err> {
         let (width, height, x, y) =
-            scanf!(s, "{u32}x{u32}+{u32}+{u32}").map_err(|e| Error::Scanf(e.to_string()))?;
+            sscanf!(s, "{u32}x{u32}+{u32}+{u32}").ok_or_else(|| Error::Scanf)?;
         Ok(Self {
             width,
             height,

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,8 +28,8 @@ pub enum Error {
     Receiver(#[from] std::sync::mpsc::RecvError),
     #[error("TOML parsing error: `{0}`")]
     Toml(#[from] toml::de::Error),
-    #[error("Scan error: `{0}`")]
-    Scanf(String),
+    #[error("Scan error")]
+    Scanf,
     #[error("Integer conversion error: `{0}`")]
     IntegerConversion(#[from] std::num::TryFromIntError),
     #[error("Template error: `{0}`")]

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -213,7 +213,7 @@ impl X11Window {
         let pango_context = pango_functions::create_context(&cairo_context);
         let layout = PangoLayout::new(&pango_context);
         let font_description = FontDescription::from_string(font);
-        pango_context.set_font_description(Some(&font_description));
+        pango_context.set_font_description(&font_description);
         let mut template = Tera::default();
         if let Err(e) =
             template.add_raw_template(NOTIFICATION_MESSAGE_TEMPLATE, raw_template.trim())


### PR DESCRIPTION
Seems like both `sscanf` and `pango` have tweaked their public API and I am not able to build project without these changes.

regarding `sscanf` see comment on this issue: https://github.com/mich101mich/sscanf/issues/15#issuecomment-3977499376.

regarding `pango`, compare signature of `set_font_description` in v0.22.4 and v0.22.6:

- https://docs.rs/pango/0.22.4/src/pango/auto/context.rs.html#169-173
- https://docs.rs/pango/0.22.6/src/pango/auto/context.rs.html#169-173
